### PR TITLE
マンガの感想＆紹介文へのコメント機能実装

### DIFF
--- a/app/assets/javascripts/public/manga_comments.coffee
+++ b/app/assets/javascripts/public/manga_comments.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/public/manga_comments.scss
+++ b/app/assets/stylesheets/public/manga_comments.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/MangaComments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/public/manga_comments_controller.rb
+++ b/app/controllers/public/manga_comments_controller.rb
@@ -1,0 +1,6 @@
+class Public::MangaCommentsController < ApplicationController
+  def create
+  end
+  def destroy
+  end
+end

--- a/app/controllers/public/manga_comments_controller.rb
+++ b/app/controllers/public/manga_comments_controller.rb
@@ -1,6 +1,28 @@
 class Public::MangaCommentsController < ApplicationController
+
+# 投稿に対するコメントの作成
   def create
+    # 投稿するためのマンガのidの習得
+    manga = Manga.find(params[:manga_id])
+    # 会員のidの習得とフォームに渡す空のデータの値を設定
+    comment = current_member.manga_comments.new(manga_comment_params)
+    # マンガのidを習得
+    comment.manga_id = manga.id
+    comment.save
+    redirect_to request.referer
   end
+
+  # コメント投稿の削除
   def destroy
+    # 削除するコメントのidを習得し削除する
+    MangaComment.find_by(id:params[:id]).destroy
+    redirect_to request.referer
   end
+
+  private
+
+  def manga_comment_params
+    params.require(:manga_comment).permit(:comment)
+  end
+
 end

--- a/app/controllers/public/mangas_controller.rb
+++ b/app/controllers/public/mangas_controller.rb
@@ -18,6 +18,7 @@ class Public::MangasController < ApplicationController
 
   def show
     @manga = Manga.find(params[:id])
+    @manga_comment = MangaComment.new
   end
 
   def edit

--- a/app/helpers/public/manga_comments_helper.rb
+++ b/app/helpers/public/manga_comments_helper.rb
@@ -1,0 +1,2 @@
+module Public::MangaCommentsHelper
+end

--- a/app/models/manga.rb
+++ b/app/models/manga.rb
@@ -1,4 +1,5 @@
 class Manga < ApplicationRecord
-  belongs_to :member
   attachment :image
+  belongs_to :member
+  has_many :manga_comments, dependent: :destroy
 end

--- a/app/models/manga_comment.rb
+++ b/app/models/manga_comment.rb
@@ -1,2 +1,5 @@
 class MangaComment < ApplicationRecord
+  belongs_to :member
+  belongs_to :manga
+  
 end

--- a/app/models/manga_comment.rb
+++ b/app/models/manga_comment.rb
@@ -1,0 +1,2 @@
+class MangaComment < ApplicationRecord
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -3,6 +3,7 @@ class Member < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :mangas
   attachment :profile_image
+  has_many :mangas, dependent: :destroy
+  has_many :manga_comments, dependent: :destroy
 end

--- a/app/views/public/manga_comments/_comment_form.html.erb
+++ b/app/views/public/manga_comments/_comment_form.html.erb
@@ -1,0 +1,6 @@
+<div>
+  <%= form_with(model: [manga, manga_comment], local: true) do |f| %>
+  <%= f.text_area :comment,rows: '5',cols:'30', placeholder: "コメント記入欄" %>
+  <%= f.submit "送信する"%>
+  <% end %>
+</div>

--- a/app/views/public/manga_comments/_manga_comment.html.erb
+++ b/app/views/public/manga_comments/_manga_comment.html.erb
@@ -1,0 +1,16 @@
+<!--マンガの紹介へのコメント-->
+<div class="text-center border-bottom">
+  <h4>
+    コメント一覧
+  </h4>
+</div>
+<div>
+  <% manga.manga_comments.each do |manga_comment|%>
+    <%= attachment_image_tag manga_comment.member, :profile_image, :fill,60,60, fallback: "no_image.jpg"%>
+    <%= manga_comment.member.nickname %>
+    <%= manga_comment.comment%>
+    <div>
+  <%= link_to 'コメントの削除',manga_manga_comment_path(manga_comment.manga, manga_comment), method: :delete%>
+</div>
+  <% end %>
+</div>

--- a/app/views/public/mangas/_show.html.erb
+++ b/app/views/public/mangas/_show.html.erb
@@ -1,23 +1,34 @@
-<!--マンガ詳細の表示h文-->
-<h4 class="">タイトル名 : <%= @manga.title%></h4>
+<!--マンガ詳細の表示テーブル文-->
+<h4 class="">タイトル名 : <%= manga.title%></h4>
 <div class="border border">
   <div class="text-center">
-  <%= attachment_image_tag @manga, :image, :fill,300,300%>
+  <%= attachment_image_tag manga, :image, :fill,300,300%>
+  </div>
+</div>
+<div class="d-flex">
+  <div class="border border col ">
+    コメント数 : <%= manga.manga_comments.count %>
+  </div>
+  <div class="border border col ">いいえ
   </div>
 </div>
 <table class="table table-bordered">
+  <thead>
+    <tr>
+    </tr>
+  </thead>
   <tbody>
     <tr>
       <td>評価</td>
-      <td><%= @manga.review%></td>
+      <td><%= manga.review%></td>
     </tr>
     <tr>
       <td>紹介</td>
-      <td><%= @manga.introduction%></td>
+      <td><%= manga.introduction%></td>
     </tr>
     <tr>
       <td>感想</td>
-      <td><%= @manga.impression%></td>
+      <td><%= manga.impression%></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/public/mangas/show.html.erb
+++ b/app/views/public/mangas/show.html.erb
@@ -5,6 +5,7 @@
         <h3 class="text-center">マンガ詳細</h3>
       </div>
       <%= render 'show', manga: @manga%>
+      <%= render 'public/manga_comments/manga_comment', manga: @manga%>
 
     </div>
     <div class="col-3">
@@ -12,5 +13,6 @@
       <%= link_to '投稿編集',edit_manga_path(@manga), class: 'btn btn-success'%>
       <%= link_to '削除',manga_path(@manga),method: :delete, "data-confirm" => "本当に削除しますか？", class: 'btn btn-danger'%>
     </div>
+      <%= render 'public/manga_comments/comment_form', manga: @manga,manga_comment: @manga_comment%>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
   # 会員側のルーティング設定
   root to: 'public/homes#top'
   scope module: 'public' do
-    resources :mangas
+    resources :mangas do
+      resources :manga_comments, only: [:create, :destroy]
+    end
     resources :members,only: [:show, :edit, :update]
   end
 

--- a/db/migrate/20220213143711_create_manga_comments.rb
+++ b/db/migrate/20220213143711_create_manga_comments.rb
@@ -1,0 +1,11 @@
+class CreateMangaComments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :manga_comments do |t|
+      t.integer :member_id
+      t.integer :manga_id
+      t.text :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_11_074732) do
+ActiveRecord::Schema.define(version: 2022_02_13_143711) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -22,6 +22,14 @@ ActiveRecord::Schema.define(version: 2022_02_11_074732) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "manga_comments", force: :cascade do |t|
+    t.integer "member_id"
+    t.integer "manga_id"
+    t.text "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "mangas", force: :cascade do |t|

--- a/test/controllers/public/manga_comments_controller_test.rb
+++ b/test/controllers/public/manga_comments_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Public::MangaCommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/manga_comments.yml
+++ b/test/fixtures/manga_comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  member_id: 1
+  manga_id: 1
+  comment: MyText
+
+two:
+  member_id: 1
+  manga_id: 1
+  comment: MyText

--- a/test/models/manga_comment_test.rb
+++ b/test/models/manga_comment_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MangaCommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- コメント機能実装
- コメント削除機能実装
- コメント一覧マンガ詳細ページへ実装
- コメント削除機能を自分のコメントの隣に設定（投稿した本人のみの表示は未設定）
***
以上が実装内容です。
developへマージ依頼です。
動作確認済みです。