### PR TITLE
top&about画面の実装

### DIFF
--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -2,4 +2,6 @@ class Public::HomesController < ApplicationController
   
   def top
   end
+  def about
+  end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -39,7 +39,7 @@
           <%= link_to "Home",root_path, class: "btn btn-outline-secondary" %>
         </li>
         <li>
-          <%= link_to "About",root_path, class: "btn btn-outline-secondary" %>
+          <%= link_to "About",about_path, class: "btn btn-outline-secondary" %>
         </li>
         <li>
           <%= link_to "新規登録", new_member_registration_path, class: "btn btn-outline-secondary" %>

--- a/app/views/public/homes/about.html.erb
+++ b/app/views/public/homes/about.html.erb
@@ -1,0 +1,18 @@
+<div class="row">
+    <div class="col text-center">
+      <h3 class="border rounded-circle">
+        マンガ好きな人と交流ができるSNSサイトです！<br>
+        マンガが好きな人が自分の好きな<br>
+        マンガについて語ったり、紹介できるサイトです！<br>
+        交流もできるのでぜひ登録してご利用ください！
+      </h3>
+      <div class="btn">
+        <p>
+          登録がまだの人は<%= link_to 'こちら',new_member_registration_path%>
+          会員の人はここから<%= link_to 'ログイン！',new_member_session_path%>
+        </p>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,0 +1,16 @@
+<div class="container">
+  <div class="row">
+    <div class="col text-center">
+      <h3 class="border rounded-circle">
+        マンガ好きのユートピアへようこそ！<br>
+        このサイトはマンガの紹介を通じて多くの<br>
+        マンガ好きと交流できるSNSサイトです。<br>
+        ご利用されるには会員の登録が必要です。
+      </h3>
+      <div class="btn">
+        <%= link_to '新規登録へ',new_member_registration_path,class: "btn btn-success "%>
+        <%= link_to 'ログイン画面へ',new_member_session_path,class: "btn btn-info "%>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
   }
   # 会員側のルーティング設定
   root to: 'public/homes#top'
+  # about画面のルーティング
+  get '/about',to: 'public/homes#about'
   scope module: 'public' do
     resources :mangas do
       # マンガの紹介＆感想文へのコメント


### PR DESCRIPTION
実装内容
- top&about画面の実装
- 両画面にログイン&新規登録画面への遷移する文字を表示
- ヘッダーのhome&aboutのボタンのパスの設定（home&about)

以上が実装内容です。
developへマージします